### PR TITLE
Fix disappearing selection triggered window

### DIFF
--- a/src/window/Translate/components/SourceArea/index.jsx
+++ b/src/window/Translate/components/SourceArea/index.jsx
@@ -41,6 +41,7 @@ export default function SourceArea(props) {
     const [recognizeServiceList] = useConfig('recognize_service_list', ['system', 'tesseract']);
     const [ttsServiceList] = useConfig('tts_service_list', ['lingva_tts']);
     const [hideWindow] = useConfig('translate_hide_window', false);
+    const [clipboardMonitor] = useConfig('clipboard_monitor', false);
     const [hideSource] = useConfig('hide_source', false);
     const [ttsPluginInfo, setTtsPluginInfo] = useState();
     const [windowType, setWindowType] = useState('[SELECTION_TRANSLATE]');
@@ -51,7 +52,8 @@ export default function SourceArea(props) {
 
     const handleNewText = async (text) => {
         text = text.trim();
-        if (hideWindow) {
+        // 仅当启用了剪贴板监听并且设置了隐藏窗口时才隐藏
+        if (hideWindow && clipboardMonitor) {
             appWindow.hide();
         } else {
             appWindow.show();


### PR DESCRIPTION
Fixes translation window always hidden issue by correctly applying 'hide window' setting only for clipboard monitoring.

The previous modification caused the `hideWindow` configuration to be applied universally, leading to the translation window being hidden immediately after any trigger (selection, hotkey, etc.). This PR adjusts the logic to hide the window only when both `hideWindow` and `clipboardMonitor` settings are active, restoring the expected behavior for other trigger methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0fe8b84-91ff-4740-b514-9cf488f587dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0fe8b84-91ff-4740-b514-9cf488f587dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

